### PR TITLE
Add logging of client's metadata in main.cpp

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -56,6 +56,8 @@ class SimplifyBoostPluginConan(ConanFile):
             del self.options.fPIC
 
     def configure(self):
+        self.options["boost"].header_only = True
+
         if self.options.shared:
             self.options.rm_safe("fPIC")
         self.options["grpc"].csharp_plugin = False

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -64,6 +64,12 @@ int main(int argc, const char** argv)
                 co_await agrpc::request(&cura::plugins::slots::simplify::v0::SimplifyService::AsyncService::RequestModify, service, server_context, request, writer, boost::asio::use_awaitable);
                 cura::plugins::slots::simplify::v0::SimplifyServiceModifyResponse response;
 
+                const auto& client_metadata = server_context.client_metadata();
+                for (const auto& pair : client_metadata)
+                {
+                    spdlog::info("Received metadata: {} = {}", std::string(pair.first.begin(), pair.first.end()), std::string(pair.second.begin(), pair.second.end()));
+                }
+
                 grpc::Status status = grpc::Status::OK;
                 try
                 {


### PR DESCRIPTION
The update refers to the enhancement of logging mechanism in main.cpp. The client's metadata, previously not logged, is now logged each time a request is made. This helps in debugging and increases visibility on the client-side actions.

Contributes to CURA-10715